### PR TITLE
cactus: add proxy redirection for documentation to einsteintoolkit.org

### DIFF
--- a/cactus/cactus.conf
+++ b/cactus/cactus.conf
@@ -53,6 +53,19 @@ CheckSpelling On
     RewriteEngine On
     RewriteRule ^/blog(.*) /var/www/wordpress_cactuscode/$1
 
+    <Location "/documentation/referencemanual/">
+    ProxyPass "http://einsteintoolkit.org/referencemanual/"
+    </Location>
+    <Location "/documentation/usersguide/">
+    ProxyPass "http://einsteintoolkit.org/usersguide/"
+    </Location>
+    <Location "/documentation/arrangements/">
+    ProxyPass "http://einsteintoolkit.org/arrangementguide/"
+    </Location>
+    <Location "/documentation/thorns/">
+    ProxyPass "http://einsteintoolkit.org/thornguide/"
+    </Location>
+
     AddOutputFilterByType DEFLATE text/plain
     AddOutputFilterByType DEFLATE text/html
     AddOutputFilterByType DEFLATE text/xml
@@ -81,6 +94,19 @@ CheckSpelling On
 #    RewriteCond %{HTTP_HOST} ^www\.cactuscode\.org$ [NC]
 #    RewriteRule ^(.*)$ http://cactuscode.org$1 [R=301,L]
     DocumentRoot /var/www/live
+
+    <Location "/documentation/referencemanual/">
+    ProxyPass "https://einsteintoolkit.org/referencemanual/"
+    </Location>
+    <Location "/documentation/usersguide/">
+    ProxyPass "https://einsteintoolkit.org/usersguide/"
+    </Location>
+    <Location "/documentation/arrangements/">
+    ProxyPass "https://einsteintoolkit.org/arrangementguide/"
+    </Location>
+    <Location "/documentation/thorns/">
+    ProxyPass "https://einsteintoolkit.org/thornguide/"
+    </Location>
 
 	 SSLEngine on
 	 SSLProtocol all -SSLv2 -SSLv3


### PR DESCRIPTION
This is an attempt to keep the number of copies of the documentation that needs to be kept up to date minimal.

An alternative is it so hook up cactuscode.org to the et jenkins server in the same way that einsteintoolkit.org is which automatically updates the documentation pages once the Jenkins server rebuilds the release docs.